### PR TITLE
Initial setup: OpenFreeMap grid coloring app (Wplace clone practice)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>OpenFreeMap クリックで色塗り</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- MapLibre（グローバルに maplibregl を提供） -->
+    <script src="https://unpkg.com/maplibre-gl/dist/maplibre-gl.js"></script>
+    <link
+      href="https://unpkg.com/maplibre-gl/dist/maplibre-gl.css"
+      rel="stylesheet"
+    />
+
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+
+    <!-- カラーパレット -->
+    <div class="palette" id="palette">
+      <button data-color="#ff0000" title="Red"></button>
+      <button data-color="#ffa500" title="Orange"></button>
+      <button data-color="#ffff00" title="Yellow"></button>
+      <button data-color="#00ff00" title="Green"></button>
+      <button data-color="#00ffff" title="Cyan"></button>
+      <button data-color="#0000ff" title="Blue"></button>
+      <button data-color="#ff00ff" title="Magenta"></button>
+      <button data-color="#000000" title="Black"></button>
+      <button data-color="#ffffff" title="White" class="with-border"></button>
+      <button data-color="__eraser__" class="eraser" title="消しゴム">⌫</button>
+    </div>
+
+    <!-- エントリ（ES Modules） -->
+    <script type="module" src="./js/main.js"></script>
+  </body>
+</html>

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,17 @@
+export const CONFIG = {
+  defaultCenter: [13.388, 52.517],
+  defaultZoom: 9.5,
+  styleUrl: "https://tiles.openfreemap.org/styles/liberty",
+  // 小さいほど細かく塗れる（度）。0.0005 ≒ 約55m
+  cellSizeDeg: 0.0005,
+  ls: {
+    center: "mapCenter",
+    zoom: "mapZoom",
+    cells: "coloredCells",
+    color: "selectedColor",
+  },
+  paletteSelector: "#palette",
+  sourceId: "paint-cells",
+  layerId: "paint-cells-fill",
+  rAFBatch: true, // クリック連打時に再描画を1フレームへバッチ
+};

--- a/js/geo.js
+++ b/js/geo.js
@@ -1,0 +1,52 @@
+import { CONFIG } from "./config.js";
+
+// cellSizeDeg の小数桁数を自動判定（キー安定化に使用）
+const DECIMALS = (() => {
+  const s = String(CONFIG.cellSizeDeg);
+  const dot = s.indexOf(".");
+  return dot >= 0 ? s.length - dot - 1 : 0;
+})();
+
+export const toFixedDeg = (value) => Number(value.toFixed(DECIMALS));
+
+export const snapToGrid = (value, cell) => {
+  // 例: 135.12349 -> 135.123（cell=0.001）
+  const snapped = Math.floor(value / cell) * cell;
+  return toFixedDeg(snapped);
+};
+
+export const gridKey = (lon, lat) => `${toFixedDeg(lon)}_${toFixedDeg(lat)}`;
+
+export const cellFeature = (lon, lat, color) => {
+  const x1 = toFixedDeg(lon);
+  const y1 = toFixedDeg(lat);
+  const x2 = toFixedDeg(lon + CONFIG.cellSizeDeg);
+  const y2 = toFixedDeg(lat + CONFIG.cellSizeDeg);
+  return {
+    type: "Feature",
+    properties: { color },
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [x1, y1],
+          [x2, y1],
+          [x2, y2],
+          [x1, y2],
+          [x1, y1],
+        ],
+      ],
+    },
+  };
+};
+
+export const buildGeoJSONFromCells = (cells) => {
+  const features = [];
+  for (const [key, color] of Object.entries(cells)) {
+    const [lonStr, latStr] = key.split("_");
+    const lon = Number(lonStr);
+    const lat = Number(latStr);
+    features.push(cellFeature(lon, lat, color));
+  }
+  return { type: "FeatureCollection", features };
+};

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,2 @@
+import { initMap } from "./map.js";
+initMap();

--- a/js/map.js
+++ b/js/map.js
@@ -1,0 +1,102 @@
+import { CONFIG } from "./config.js";
+import { State } from "./state.js";
+import { snapToGrid, gridKey, buildGeoJSONFromCells } from "./geo.js";
+import { setupPalette, markActivePaletteButton } from "./palette.js";
+import {
+  loadInitialView,
+  loadCells,
+  persistCells,
+  persistView,
+  loadColor,
+} from "./storage.js";
+
+export function initMap() {
+  const { center, zoom } = loadInitialView();
+  State.coloredCells = loadCells();
+  State.currentColor = loadColor();
+
+  State.map = new maplibregl.Map({
+    style: CONFIG.styleUrl,
+    center,
+    zoom,
+    container: "map",
+  });
+
+  State.map.addControl(
+    new maplibregl.NavigationControl({ showCompass: false }),
+    "top-right"
+  );
+  State.map.addControl(new maplibregl.FullscreenControl(), "top-right");
+
+  State.map.on("moveend", persistView);
+
+  State.map.on("load", () => {
+    State.map.addSource(CONFIG.sourceId, {
+      type: "geojson",
+      data: buildGeoJSONFromCells(State.coloredCells),
+    });
+
+    State.map.addLayer({
+      id: CONFIG.layerId,
+      type: "fill",
+      source: CONFIG.sourceId,
+      paint: {
+        // 値欠損時のフォールバックを入れて堅牢化
+        "fill-color": [
+          "case",
+          ["has", "color"],
+          ["to-color", ["get", "color"]],
+          "#ff0000",
+        ],
+        "fill-opacity": 0.9,
+      },
+    });
+
+    // 初期選択中のパレット表示
+    markActivePaletteButton(State.currentColor);
+  });
+
+  State.map.on("click", (e) => {
+    const [lon, lat] = e.lngLat.toArray();
+    const slon = snapToGrid(lon, CONFIG.cellSizeDeg);
+    const slat = snapToGrid(lat, CONFIG.cellSizeDeg);
+    const key = gridKey(slon, slat);
+
+    if (State.currentColor === "__eraser__") {
+      delete State.coloredCells[key];
+    } else {
+      State.coloredCells[key] = State.currentColor;
+    }
+
+    persistCells();
+    requestUpdate();
+  });
+
+  // 欠損アイコンを握りつぶす（必要なら）
+  State.map.on("styleimagemissing", (e) => {
+    if (State.map.hasImage(e.id)) return;
+    const data = new Uint8Array(4); // 透明1px
+    State.map.addImage(e.id, { width: 1, height: 1, data });
+  });
+
+  setupPalette();
+}
+
+function requestUpdate() {
+  if (!CONFIG.rAFBatch) {
+    updateSource();
+    return;
+  }
+  if (State._updateScheduled) return;
+  State._updateScheduled = true;
+  requestAnimationFrame(() => {
+    updateSource();
+    State._updateScheduled = false;
+  });
+}
+
+function updateSource() {
+  const src = State.map.getSource(CONFIG.sourceId);
+  if (!src) return;
+  src.setData(buildGeoJSONFromCells(State.coloredCells));
+}

--- a/js/palette.js
+++ b/js/palette.js
@@ -1,0 +1,30 @@
+import { CONFIG } from "./config.js";
+import { State } from "./state.js";
+import { persistColor } from "./storage.js";
+
+export function setupPalette() {
+  const el = document.querySelector(CONFIG.paletteSelector);
+  if (!el) return;
+
+  const buttons = el.querySelectorAll("button[data-color]");
+  buttons.forEach((btn) => {
+    const color = btn.dataset.color;
+    if (color !== "__eraser__") btn.style.background = color;
+    btn.addEventListener("click", () => {
+      State.currentColor = color;
+      persistColor(color);
+      markActivePaletteButton(color);
+    });
+  });
+
+  // 初期状態のハイライト
+  markActivePaletteButton(State.currentColor);
+}
+
+export function markActivePaletteButton(color) {
+  const el = document.querySelector(CONFIG.paletteSelector);
+  if (!el) return;
+  el.querySelectorAll("button").forEach((b) => b.classList.remove("is-active"));
+  const active = el.querySelector(`button[data-color="${CSS.escape(color)}"]`);
+  if (active) active.classList.add("is-active");
+}

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,6 @@
+export const State = {
+  map: null,
+  coloredCells: {}, // { "lon_lat": "#rrggbb" }
+  currentColor: "#ff0000",
+  _updateScheduled: false,
+};

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,31 @@
+import { CONFIG } from "./config.js";
+import { State } from "./state.js";
+import { safeJsonParse, safeLocalGet, safeLocalSet } from "./utils.js";
+
+export const loadInitialView = () => {
+  let center = CONFIG.defaultCenter;
+  let zoom = CONFIG.defaultZoom;
+  const savedCenter = safeLocalGet(CONFIG.ls.center, null);
+  const savedZoom = safeLocalGet(CONFIG.ls.zoom, null);
+  if (savedCenter) center = safeJsonParse(savedCenter, CONFIG.defaultCenter);
+  if (savedZoom) zoom = parseFloat(savedZoom) || CONFIG.defaultZoom;
+  return { center, zoom };
+};
+
+export const loadCells = () => {
+  const raw = safeLocalGet(CONFIG.ls.cells, null);
+  return raw ? safeJsonParse(raw, {}) : {};
+};
+
+export const persistCells = () => {
+  safeLocalSet(CONFIG.ls.cells, JSON.stringify(State.coloredCells));
+};
+
+export const persistView = () => {
+  const c = State.map.getCenter().toArray();
+  safeLocalSet(CONFIG.ls.center, JSON.stringify(c));
+  safeLocalSet(CONFIG.ls.zoom, String(State.map.getZoom()));
+};
+
+export const loadColor = () => safeLocalGet(CONFIG.ls.color, "#ff0000");
+export const persistColor = (color) => safeLocalSet(CONFIG.ls.color, color);

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,20 @@
+export const safeJsonParse = (text, fallback) => {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+};
+
+export const safeLocalGet = (k, fallback) => {
+  const v = localStorage.getItem(k);
+  return v == null ? fallback : v;
+};
+
+export const safeLocalSet = (k, v) => {
+  try {
+    localStorage.setItem(k, v);
+  } catch {
+    /* ignore */
+  }
+};

--- a/style.css
+++ b/style.css
@@ -1,0 +1,52 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+}
+#map {
+  width: 100vw;
+  height: 100dvh;
+  height: 100vh;
+}
+
+.palette {
+  position: fixed;
+  left: 12px;
+  bottom: 12px;
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  z-index: 10;
+}
+.palette button {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+}
+.palette button.with-border {
+  border: 1px solid #ccc;
+}
+.palette button.eraser {
+  width: 42px;
+  font-weight: 700;
+  background: #eee;
+  border: 1px solid #ccc;
+}
+.palette button.is-active {
+  outline: 2px solid #333;
+  outline-offset: 1px;
+}
+
+@supports (padding: max(0px)) {
+  .palette {
+    margin-bottom: max(env(safe-area-inset-bottom), 12px);
+    margin-left: max(env(safe-area-inset-left), 12px);
+  }
+}


### PR DESCRIPTION
This PR adds the initial implementation of an OpenFreeMap + MapLibre GL JS web app, inspired by Wplace.

**Key features:**
- Display a map using OpenFreeMap (Liberty style) via MapLibre GL JS
- Click to color snapped grid cells (approx. 55m square)
- Color palette UI and eraser mode
- Save map center/zoom, selected color, and painted cells to localStorage
- Project structure split into HTML, CSS, and JS ES modules
- Added MIT License and README with setup instructions

**How to test:**
- Please refer to the README.md file, which will be added in the next pull request.